### PR TITLE
issue #2 repro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ decl_storage! {
 		// Just a dummy storage item.
 		// Here we are declaring a StorageValue, `Something` as a Option<u32>
 		// `get(something)` is the default getter which returns either the stored `u32` or `None` if nothing stored
-		Something get(something): Option<u32>;
+		Something get(something) config(): Option<u32>;
 	}
 }
 


### PR DESCRIPTION
Hello,

I think the change I made is valid, but the code fails to compile:

```
error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
  --> src/lib.rs:25:1
   |
25 | / decl_storage! {
26 | |     trait Store for Module<T: Trait> as SubstrateModuleTemplate {
27 | |         // Just a dummy storage item.
28 | |         // Here we are declaring a StorageValue, `Something` as a Option<u32>
...  |
31 | |     }
32 | | }
   | |_^
   |
   = note: for more information, see https://github.com/rust-lang/rust/issues/27812

error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
  --> src/lib.rs:25:1
   |
25 | / decl_storage! {
26 | |     trait Store for Module<T: Trait> as SubstrateModuleTemplate {
27 | |         // Just a dummy storage item.
28 | |         // Here we are declaring a StorageValue, `Something` as a Option<u32>
...  |
31 | |     }
32 | | }
   | |_^
   |
   = note: for more information, see https://github.com/rust-lang/rust/issues/27812

error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
  --> src/lib.rs:25:1
   |
25 | / decl_storage! {
26 | |     trait Store for Module<T: Trait> as SubstrateModuleTemplate {
27 | |         // Just a dummy storage item.
28 | |         // Here we are declaring a StorageValue, `Something` as a Option<u32>
...  |
31 | |     }
32 | | }
   | |_^
   |
   = note: for more information, see https://github.com/rust-lang/rust/issues/27812

error: aborting due to 3 previous errors

For more information about this error, try `rustc --explain E0658`.
error: Could not compile `substrate-module-template`.

To learn more, run the command again with --verbose.
```