### PR TITLE
Update Cargo.toml to fix `config()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,6 +1253,7 @@ name = "substrate-module-template"
 version = "0.1.0"
 dependencies = [
  "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3ba0f2a2dbd37c31851a0ff1c1c0c47aa940de90)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3ba0f2a2dbd37c31851a0ff1c1c0c47aa940de90)",
  "srml-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3ba0f2a2dbd37c31851a0ff1c1c0c47aa940de90)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,21 @@
 [package]
 name = "substrate-module-template"
 version = "0.1.0"
-authors = ["Shawn Tabrizi <shawntabrizi@gmail.com>"]
+authors = ["Anonymous"]
 edition = "2018"
 
 [features]
 default = ['std']
 std = [
+    'serde',
     'codec/std',
     'support/std',
     'system/std',
 ]
+
+[dependencies.serde]
+version = "1.0"
+optional = true
 
 [dependencies.codec]
 default-features = false


### PR DESCRIPTION
This fixes the following error:

```
error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
  --> src/lib.rs:25:1
   |
25 | / decl_storage! {
26 | |     trait Store for Module<T: Trait> as SubstrateModuleTemplate {
27 | |         // Just a dummy storage item.
28 | |         // Here we are declaring a StorageValue, `Something` as a Option<u32>
...  |
31 | |     }
32 | | }
   | | ^ in this macro invocation
   | |_|
   | 
   |
   = note: for more information, see https://github.com/rust-lang/rust/issues/27812
   = help: add `#![feature(rustc_private)]` to the crate attributes to enable
```

Which appears when you try to create a `config()` storage item.

Someone can feel free to comment why this is the case...